### PR TITLE
[feat] Bottom navigation 구현

### DIFF
--- a/app/src/main/java/org/android/bbangzip/presentation/type/BottomNavigationType.kt
+++ b/app/src/main/java/org/android/bbangzip/presentation/type/BottomNavigationType.kt
@@ -31,7 +31,8 @@ enum class BottomNavigationType(
         bottomNaviIcon = R.drawable.ic_user_one_default_24,
         bottomNaviTitle = R.string.bottomNavigation_fourth_tab_title,
         route = BottomNavigationRoute.My,
-    );
+    ),
+    ;
 
     companion object {
         @Composable

--- a/app/src/main/java/org/android/bbangzip/presentation/type/BottomNavigationType.kt
+++ b/app/src/main/java/org/android/bbangzip/presentation/type/BottomNavigationType.kt
@@ -13,31 +13,25 @@ enum class BottomNavigationType(
     val route: BottomNavigationRoute,
 ) {
     SUBJECT(
-        bottomNaviIcon = R.drawable.ic_dummy_24,
-        bottomNaviTitle = R.string.dummy,
+        bottomNaviIcon = R.drawable.ic_book_default_24,
+        bottomNaviTitle = R.string.bottomNavigation_first_tab_title,
         route = BottomNavigationRoute.Subject,
     ),
     TODO(
-        bottomNaviIcon = R.drawable.ic_dummy_24,
-        bottomNaviTitle = R.string.dummy,
+        bottomNaviIcon = R.drawable.ic_file_check_default_24,
+        bottomNaviTitle = R.string.bottomNavigation_second_tab_title,
         route = BottomNavigationRoute.Todo,
     ),
     FRIEND(
-        bottomNaviIcon = R.drawable.ic_dummy_24,
-        bottomNaviTitle = R.string.dummy,
+        bottomNaviIcon = R.drawable.ic_messagebox_default_24,
+        bottomNaviTitle = R.string.bottomNavigation_third_tab_title,
         route = BottomNavigationRoute.Friend,
     ),
     MY(
-        bottomNaviIcon = R.drawable.ic_dummy_24,
-        bottomNaviTitle = R.string.dummy,
+        bottomNaviIcon = R.drawable.ic_user_one_default_24,
+        bottomNaviTitle = R.string.bottomNavigation_fourth_tab_title,
         route = BottomNavigationRoute.My,
-    ),
-    DUMMY(
-        bottomNaviIcon = R.drawable.ic_dummy_24,
-        bottomNaviTitle = R.string.dummy,
-        route = BottomNavigationRoute.Dummy,
-    ),
-    ;
+    );
 
     companion object {
         @Composable

--- a/app/src/main/java/org/android/bbangzip/presentation/type/BottomNavigationType.kt
+++ b/app/src/main/java/org/android/bbangzip/presentation/type/BottomNavigationType.kt
@@ -14,22 +14,22 @@ enum class BottomNavigationType(
 ) {
     SUBJECT(
         bottomNaviIcon = R.drawable.ic_book_default_24,
-        bottomNaviTitle = R.string.bottomNavigation_first_tab_title,
+        bottomNaviTitle = R.string.bottomNavigation_subject_tab_title,
         route = BottomNavigationRoute.Subject,
     ),
     TODO(
         bottomNaviIcon = R.drawable.ic_file_check_default_24,
-        bottomNaviTitle = R.string.bottomNavigation_second_tab_title,
+        bottomNaviTitle = R.string.bottomNavigation_todo_tab_title,
         route = BottomNavigationRoute.Todo,
     ),
     FRIEND(
         bottomNaviIcon = R.drawable.ic_messagebox_default_24,
-        bottomNaviTitle = R.string.bottomNavigation_third_tab_title,
+        bottomNaviTitle = R.string.bottomNavigation_friend_tab_title,
         route = BottomNavigationRoute.Friend,
     ),
     MY(
         bottomNaviIcon = R.drawable.ic_user_one_default_24,
-        bottomNaviTitle = R.string.bottomNavigation_fourth_tab_title,
+        bottomNaviTitle = R.string.bottomNavigation_my_tab_title,
         route = BottomNavigationRoute.My,
     ),
     ;

--- a/app/src/main/java/org/android/bbangzip/presentation/ui/navigator/MainActivity.kt
+++ b/app/src/main/java/org/android/bbangzip/presentation/ui/navigator/MainActivity.kt
@@ -4,17 +4,14 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
-import androidx.compose.ui.graphics.Color
-import androidx.core.view.WindowCompat
 import dagger.hilt.android.AndroidEntryPoint
 import org.android.bbangzip.ui.theme.BBANGZIPTheme
 
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
-
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-
+        enableEdgeToEdge()
         setContent {
             val navigator: MainNavigator = rememberMainNavigator()
 

--- a/app/src/main/java/org/android/bbangzip/presentation/ui/navigator/MainActivity.kt
+++ b/app/src/main/java/org/android/bbangzip/presentation/ui/navigator/MainActivity.kt
@@ -4,14 +4,17 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import androidx.compose.ui.graphics.Color
+import androidx.core.view.WindowCompat
 import dagger.hilt.android.AndroidEntryPoint
 import org.android.bbangzip.ui.theme.BBANGZIPTheme
 
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        enableEdgeToEdge()
+
         setContent {
             val navigator: MainNavigator = rememberMainNavigator()
 

--- a/app/src/main/java/org/android/bbangzip/presentation/ui/navigator/MainNavHost.kt
+++ b/app/src/main/java/org/android/bbangzip/presentation/ui/navigator/MainNavHost.kt
@@ -25,7 +25,7 @@ fun MainNavHost(
         modifier =
             modifier
                 .fillMaxSize()
-                .padding(padding)
+                .padding(top = padding.calculateTopPadding())
                 .background(MaterialTheme.colorScheme.surfaceDim),
     ) {
         NavHost(

--- a/app/src/main/java/org/android/bbangzip/presentation/ui/navigator/MainNavigator.kt
+++ b/app/src/main/java/org/android/bbangzip/presentation/ui/navigator/MainNavigator.kt
@@ -11,7 +11,6 @@ import androidx.navigation.navOptions
 import org.android.bbangzip.presentation.model.BottomNavigationRoute
 import org.android.bbangzip.presentation.model.Route
 import org.android.bbangzip.presentation.type.BottomNavigationType
-import org.android.bbangzip.presentation.ui.dummy.navigation.navigateDummy
 import org.android.bbangzip.presentation.ui.friend.navigateFriend
 import org.android.bbangzip.presentation.ui.my.navigateMy
 import org.android.bbangzip.presentation.ui.subject.navigateSubject

--- a/app/src/main/java/org/android/bbangzip/presentation/ui/navigator/MainNavigator.kt
+++ b/app/src/main/java/org/android/bbangzip/presentation/ui/navigator/MainNavigator.kt
@@ -49,7 +49,6 @@ class MainNavigator(
                 BottomNavigationType.TODO -> navHostController.navigateTodo(navOptions)
                 BottomNavigationType.FRIEND -> navHostController.navigateFriend(navOptions)
                 BottomNavigationType.MY -> navHostController.navigateMy(navOptions)
-                BottomNavigationType.DUMMY -> navHostController.navigateDummy(navOptions)
                 else -> Unit
             }
             Timber.d("[navigation] currentDestination -> ${navHostController.currentDestination}")

--- a/app/src/main/java/org/android/bbangzip/presentation/ui/navigator/MainScreen.kt
+++ b/app/src/main/java/org/android/bbangzip/presentation/ui/navigator/MainScreen.kt
@@ -15,6 +15,7 @@ import okhttp3.internal.toImmutableList
 import org.android.bbangzip.presentation.type.BottomNavigationType
 import org.android.bbangzip.presentation.ui.navigator.component.BottomNavigationBar
 import org.android.bbangzip.ui.theme.BBANGZIPTheme
+import org.android.bbangzip.ui.theme.defaultBbangZipColors
 
 @Composable
 fun MainScreen(
@@ -31,7 +32,7 @@ private fun MainScreenContent(
     navigator: MainNavigator,
 ) {
     Scaffold(
-        modifier = modifier.padding(WindowInsets.navigationBars.asPaddingValues()),
+//        modifier = modifier.padding(WindowInsets.navigationBars.asPaddingValues()),
         content = { padding ->
             MainNavHost(
                 navigator = navigator,
@@ -41,10 +42,6 @@ private fun MainScreenContent(
         bottomBar = {
             BottomNavigationBar(
                 isVisible = navigator.showBottomBar(),
-                modifier =
-                    Modifier
-                        .background(Color.Green)
-                        .padding(top = 8.dp, bottom = 10.dp),
                 bottomNaviBarItems = BottomNavigationType.entries.toImmutableList(),
                 currentNaviBarItemSelected = navigator.currentBottomNavigationBarItem,
                 onBottomNaviBarItemSelected = { navigator.navigateBottomNavigation(it) },

--- a/app/src/main/java/org/android/bbangzip/presentation/ui/navigator/MainScreen.kt
+++ b/app/src/main/java/org/android/bbangzip/presentation/ui/navigator/MainScreen.kt
@@ -1,6 +1,5 @@
 package org.android.bbangzip.presentation.ui.navigator
 
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.navigationBars
@@ -8,14 +7,11 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.dp
 import okhttp3.internal.toImmutableList
 import org.android.bbangzip.presentation.type.BottomNavigationType
 import org.android.bbangzip.presentation.ui.navigator.component.BottomNavigationBar
 import org.android.bbangzip.ui.theme.BBANGZIPTheme
-import org.android.bbangzip.ui.theme.defaultBbangZipColors
 
 @Composable
 fun MainScreen(
@@ -32,7 +28,7 @@ private fun MainScreenContent(
     navigator: MainNavigator,
 ) {
     Scaffold(
-//        modifier = modifier.padding(WindowInsets.navigationBars.asPaddingValues()),
+        modifier = modifier.padding(WindowInsets.navigationBars.asPaddingValues()),
         content = { padding ->
             MainNavHost(
                 navigator = navigator,

--- a/app/src/main/java/org/android/bbangzip/presentation/ui/navigator/component/BottomNavigationBar.kt
+++ b/app/src/main/java/org/android/bbangzip/presentation/ui/navigator/component/BottomNavigationBar.kt
@@ -3,6 +3,22 @@ package org.android.bbangzip.presentation.ui.navigator.component
 import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
 import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.expandHorizontally
+import androidx.compose.animation.expandIn
+import androidx.compose.animation.expandVertically
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.scaleIn
+import androidx.compose.animation.scaleOut
+import androidx.compose.animation.shrinkHorizontally
+import androidx.compose.animation.shrinkOut
+import androidx.compose.animation.shrinkVertically
+import androidx.compose.animation.slideIn
+import androidx.compose.animation.slideInHorizontally
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.slideOut
+import androidx.compose.animation.slideOutHorizontally
+import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -23,6 +39,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.center
 import androidx.compose.ui.unit.dp
 import okhttp3.internal.toImmutableList
 import org.android.bbangzip.R
@@ -41,7 +58,11 @@ fun BottomNavigationBar(
     onBottomNaviBarItemSelected: (BottomNavigationType) -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    AnimatedVisibility(visible = isVisible) {
+    AnimatedVisibility(
+        visible = isVisible,
+        enter = slideInVertically(),
+        exit = slideOutVertically(),
+        ) {
         Box(
             modifier =
                 modifier

--- a/app/src/main/java/org/android/bbangzip/presentation/ui/navigator/component/BottomNavigationBar.kt
+++ b/app/src/main/java/org/android/bbangzip/presentation/ui/navigator/component/BottomNavigationBar.kt
@@ -5,17 +5,21 @@ import androidx.annotation.StringRes
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -25,8 +29,12 @@ import androidx.compose.ui.unit.dp
 import okhttp3.internal.toImmutableList
 import org.android.bbangzip.R
 import org.android.bbangzip.presentation.type.BottomNavigationType
+import org.android.bbangzip.presentation.util.modifier.dropShadow
 import org.android.bbangzip.presentation.util.modifier.noRippleClickable
 import org.android.bbangzip.ui.theme.BBANGZIPTheme
+import org.android.bbangzip.ui.theme.BbangZipColors
+import org.android.bbangzip.ui.theme.defaultBbangZipColors
+import org.android.bbangzip.ui.theme.defaultBbangZipTypography
 
 @Composable
 fun BottomNavigationBar(
@@ -37,19 +45,36 @@ fun BottomNavigationBar(
     modifier: Modifier = Modifier,
 ) {
     AnimatedVisibility(visible = isVisible) {
-        Row(
-            modifier = modifier.fillMaxWidth(),
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.SpaceAround,
+        Box(
+            modifier = modifier
+                .fillMaxWidth()
+                .background(color = defaultBbangZipColors.backgroundNormal_FFFFFF)
+                .dropShadow(
+                    offsetY = (-4).dp,
+                    shape = RoundedCornerShape(topStart = 32.dp, topEnd = 32.dp)
+                ),
         ) {
-            bottomNaviBarItems.forEach { navItem ->
-                BottomNavigationItem(
-                    isSelected = currentNaviBarItemSelected == navItem,
-                    bottomNaviType = navItem,
-                    onBottomNaviBarItemSelected = onBottomNaviBarItemSelected,
-                    bottomNaviIcon = navItem.bottomNaviIcon,
-                    bottomNaviTitle = navItem.bottomNaviTitle,
-                )
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clip(
+                        shape = RoundedCornerShape(topStart = 32.dp, topEnd = 32.dp)
+                    )
+                    .background(color = defaultBbangZipColors.backgroundNormal_FFFFFF)
+                    .padding(top = 12.dp, bottom = 8.dp, start = 12.dp, end = 12.dp)
+                ,
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.SpaceBetween,
+            ) {
+                bottomNaviBarItems.forEach { navItem ->
+                    BottomNavigationItem(
+                        isSelected = currentNaviBarItemSelected == navItem,
+                        bottomNaviType = navItem,
+                        onBottomNaviBarItemSelected = onBottomNaviBarItemSelected,
+                        bottomNaviIcon = navItem.bottomNaviIcon,
+                        bottomNaviTitle = navItem.bottomNaviTitle,
+                    )
+                }
             }
         }
     }
@@ -67,21 +92,26 @@ private fun BottomNavigationItem(
 ) {
     Column(
         modifier =
-            modifier.noRippleClickable {
-                onBottomNaviBarItemSelected(bottomNaviType)
-            },
+            modifier
+                .noRippleClickable {
+                    onBottomNaviBarItemSelected(bottomNaviType)
+                },
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
-        Icon(
-            painter = painterResource(id = bottomNaviIcon),
-            contentDescription = stringResource(id = R.string.app_name),
-            tint =
-                if (isSelected) {
-                    Color.Gray
-                } else {
-                    Color.White
-                },
-        )
+        Box(
+            modifier = Modifier.padding(horizontal = 24.dp),
+        ) {
+            Icon(
+                painter = painterResource(id = bottomNaviIcon),
+                contentDescription = stringResource(id = R.string.app_name),
+                tint =
+                    if (isSelected) {
+                        defaultBbangZipColors.labelNormal_282119
+                    } else {
+                        defaultBbangZipColors.labelAssistive_282119_28
+                    },
+            )
+        }
 
         Spacer(modifier = Modifier.height(spacing))
 
@@ -89,10 +119,11 @@ private fun BottomNavigationItem(
             text = stringResource(bottomNaviTitle),
             color =
                 if (isSelected) {
-                    Color.Gray
+                    defaultBbangZipColors.labelNormal_282119
                 } else {
-                    Color.White
+                    defaultBbangZipColors.labelAssistive_282119_28
                 },
+            style = defaultBbangZipTypography.caption1Bold,
         )
     }
 }
@@ -103,12 +134,8 @@ fun BottomNavigationBarPreview() {
     BBANGZIPTheme {
         BottomNavigationBar(
             isVisible = true,
-            modifier =
-                Modifier
-                    .background(Color.Blue)
-                    .padding(top = 5.dp, bottom = 10.dp),
             bottomNaviBarItems = BottomNavigationType.entries.toImmutableList(),
-            currentNaviBarItemSelected = BottomNavigationType.DUMMY,
+            currentNaviBarItemSelected = BottomNavigationType.SUBJECT,
             onBottomNaviBarItemSelected = {},
         )
     }

--- a/app/src/main/java/org/android/bbangzip/presentation/ui/navigator/component/BottomNavigationBar.kt
+++ b/app/src/main/java/org/android/bbangzip/presentation/ui/navigator/component/BottomNavigationBar.kt
@@ -1,6 +1,5 @@
 package org.android.bbangzip.presentation.ui.navigator.component
 
-import android.content.res.Resources.Theme
 import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
 import androidx.compose.animation.AnimatedVisibility
@@ -24,7 +23,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.tooling.preview.Preview
@@ -37,8 +35,6 @@ import org.android.bbangzip.presentation.util.modifier.dropShadow
 import org.android.bbangzip.presentation.util.modifier.noRippleClickable
 import org.android.bbangzip.ui.theme.BBANGZIPTheme
 import org.android.bbangzip.ui.theme.BbangZipTheme
-import org.android.bbangzip.ui.theme.defaultBbangZipColors
-import org.android.bbangzip.ui.theme.defaultBbangZipTypography
 
 @Composable
 fun BottomNavigationBar(

--- a/app/src/main/java/org/android/bbangzip/presentation/ui/navigator/component/BottomNavigationBar.kt
+++ b/app/src/main/java/org/android/bbangzip/presentation/ui/navigator/component/BottomNavigationBar.kt
@@ -3,21 +3,7 @@ package org.android.bbangzip.presentation.ui.navigator.component
 import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
 import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.animation.expandHorizontally
-import androidx.compose.animation.expandIn
-import androidx.compose.animation.expandVertically
-import androidx.compose.animation.fadeIn
-import androidx.compose.animation.fadeOut
-import androidx.compose.animation.scaleIn
-import androidx.compose.animation.scaleOut
-import androidx.compose.animation.shrinkHorizontally
-import androidx.compose.animation.shrinkOut
-import androidx.compose.animation.shrinkVertically
-import androidx.compose.animation.slideIn
-import androidx.compose.animation.slideInHorizontally
 import androidx.compose.animation.slideInVertically
-import androidx.compose.animation.slideOut
-import androidx.compose.animation.slideOutHorizontally
 import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
@@ -39,7 +25,6 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
-import androidx.compose.ui.unit.center
 import androidx.compose.ui.unit.dp
 import okhttp3.internal.toImmutableList
 import org.android.bbangzip.R
@@ -62,7 +47,7 @@ fun BottomNavigationBar(
         visible = isVisible,
         enter = slideInVertically(),
         exit = slideOutVertically(),
-        ) {
+    ) {
         Box(
             modifier =
                 modifier

--- a/app/src/main/java/org/android/bbangzip/presentation/ui/navigator/component/BottomNavigationBar.kt
+++ b/app/src/main/java/org/android/bbangzip/presentation/ui/navigator/component/BottomNavigationBar.kt
@@ -9,7 +9,6 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -20,7 +19,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
@@ -32,7 +30,6 @@ import org.android.bbangzip.presentation.type.BottomNavigationType
 import org.android.bbangzip.presentation.util.modifier.dropShadow
 import org.android.bbangzip.presentation.util.modifier.noRippleClickable
 import org.android.bbangzip.ui.theme.BBANGZIPTheme
-import org.android.bbangzip.ui.theme.BbangZipColors
 import org.android.bbangzip.ui.theme.defaultBbangZipColors
 import org.android.bbangzip.ui.theme.defaultBbangZipTypography
 
@@ -46,23 +43,24 @@ fun BottomNavigationBar(
 ) {
     AnimatedVisibility(visible = isVisible) {
         Box(
-            modifier = modifier
-                .fillMaxWidth()
-                .background(color = defaultBbangZipColors.backgroundNormal_FFFFFF)
-                .dropShadow(
-                    offsetY = (-4).dp,
-                    shape = RoundedCornerShape(topStart = 32.dp, topEnd = 32.dp)
-                ),
+            modifier =
+                modifier
+                    .fillMaxWidth()
+                    .background(color = defaultBbangZipColors.backgroundNormal_FFFFFF)
+                    .dropShadow(
+                        offsetY = (-4).dp,
+                        shape = RoundedCornerShape(topStart = 32.dp, topEnd = 32.dp),
+                    ),
         ) {
             Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .clip(
-                        shape = RoundedCornerShape(topStart = 32.dp, topEnd = 32.dp)
-                    )
-                    .background(color = defaultBbangZipColors.backgroundNormal_FFFFFF)
-                    .padding(top = 12.dp, bottom = 8.dp, start = 12.dp, end = 12.dp)
-                ,
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .clip(
+                            shape = RoundedCornerShape(topStart = 32.dp, topEnd = 32.dp),
+                        )
+                        .background(color = defaultBbangZipColors.backgroundNormal_FFFFFF)
+                        .padding(top = 12.dp, bottom = 8.dp, start = 12.dp, end = 12.dp),
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.SpaceBetween,
             ) {

--- a/app/src/main/java/org/android/bbangzip/presentation/ui/navigator/component/BottomNavigationBar.kt
+++ b/app/src/main/java/org/android/bbangzip/presentation/ui/navigator/component/BottomNavigationBar.kt
@@ -1,5 +1,6 @@
 package org.android.bbangzip.presentation.ui.navigator.component
 
+import android.content.res.Resources.Theme
 import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
 import androidx.compose.animation.AnimatedVisibility
@@ -21,8 +22,11 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
@@ -32,6 +36,7 @@ import org.android.bbangzip.presentation.type.BottomNavigationType
 import org.android.bbangzip.presentation.util.modifier.dropShadow
 import org.android.bbangzip.presentation.util.modifier.noRippleClickable
 import org.android.bbangzip.ui.theme.BBANGZIPTheme
+import org.android.bbangzip.ui.theme.BbangZipTheme
 import org.android.bbangzip.ui.theme.defaultBbangZipColors
 import org.android.bbangzip.ui.theme.defaultBbangZipTypography
 
@@ -52,7 +57,7 @@ fun BottomNavigationBar(
             modifier =
                 modifier
                     .fillMaxWidth()
-                    .background(color = defaultBbangZipColors.backgroundNormal_FFFFFF)
+                    .background(color = Color.Transparent)
                     .dropShadow(
                         offsetY = (-4).dp,
                         shape = RoundedCornerShape(topStart = 32.dp, topEnd = 32.dp),
@@ -65,7 +70,7 @@ fun BottomNavigationBar(
                         .clip(
                             shape = RoundedCornerShape(topStart = 32.dp, topEnd = 32.dp),
                         )
-                        .background(color = defaultBbangZipColors.backgroundNormal_FFFFFF)
+                        .background(color = BbangZipTheme.colors.backgroundNormal_FFFFFF)
                         .padding(top = 12.dp, bottom = 8.dp, start = 12.dp, end = 12.dp),
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.SpaceBetween,
@@ -106,13 +111,13 @@ private fun BottomNavigationItem(
             modifier = Modifier.padding(horizontal = 24.dp),
         ) {
             Icon(
-                painter = painterResource(id = bottomNaviIcon),
+                imageVector = ImageVector.vectorResource(id = bottomNaviIcon),
                 contentDescription = stringResource(id = R.string.app_name),
                 tint =
                     if (isSelected) {
-                        defaultBbangZipColors.labelNormal_282119
+                        BbangZipTheme.colors.labelNormal_282119
                     } else {
-                        defaultBbangZipColors.labelAssistive_282119_28
+                        BbangZipTheme.colors.labelAssistive_282119_28
                     },
             )
         }
@@ -123,11 +128,11 @@ private fun BottomNavigationItem(
             text = stringResource(bottomNaviTitle),
             color =
                 if (isSelected) {
-                    defaultBbangZipColors.labelNormal_282119
+                    BbangZipTheme.colors.labelNormal_282119
                 } else {
-                    defaultBbangZipColors.labelAssistive_282119_28
+                    BbangZipTheme.colors.labelAssistive_282119_28
                 },
-            style = defaultBbangZipTypography.caption1Bold,
+            style = BbangZipTheme.typography.caption1Bold,
         )
     }
 }

--- a/app/src/main/java/org/android/bbangzip/presentation/ui/subject/SubjectScreen.kt
+++ b/app/src/main/java/org/android/bbangzip/presentation/ui/subject/SubjectScreen.kt
@@ -1,12 +1,18 @@
 package org.android.bbangzip.presentation.ui.subject
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import org.android.bbangzip.ui.theme.defaultBbangZipColors
 
 @Composable
 fun SubjectScreen(
     modifier: Modifier = Modifier,
 ) {
-    Text("subject 탭")
+    Column(modifier = Modifier.fillMaxSize().background(color = defaultBbangZipColors.backgroundNormal_FFFFFF)) {
+        Text("subject 탭")
+    }
 }

--- a/app/src/main/java/org/android/bbangzip/presentation/util/modifier/ModifierExt.kt
+++ b/app/src/main/java/org/android/bbangzip/presentation/util/modifier/ModifierExt.kt
@@ -40,14 +40,15 @@ fun Modifier.dropShadow(
     blur: Dp = 4.dp,
     offsetY: Dp = 4.dp,
     offsetX: Dp = 0.dp,
-    spread: Dp = 0.dp
+    spread: Dp = 0.dp,
 ) = this.drawBehind {
     val shadowSize = Size(size.width + spread.toPx(), size.height + spread.toPx())
     val shadowOutline = shape.createOutline(shadowSize, layoutDirection, this)
 
-    val paint = Paint().apply {
-        this.color = color
-    }
+    val paint =
+        Paint().apply {
+            this.color = color
+        }
 
     if (blur.toPx() > 0) {
         paint.asFrameworkPaint().apply {

--- a/app/src/main/java/org/android/bbangzip/presentation/util/modifier/ModifierExt.kt
+++ b/app/src/main/java/org/android/bbangzip/presentation/util/modifier/ModifierExt.kt
@@ -1,11 +1,21 @@
 package org.android.bbangzip.presentation.util.modifier
 
+import android.graphics.BlurMaskFilter
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Paint
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.graphics.drawOutline
+import androidx.compose.ui.graphics.drawscope.drawIntoCanvas
 import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
 
 @Composable
 fun Modifier.noRippleClickable(
@@ -22,3 +32,33 @@ fun Modifier.noRippleClickable(
         onClickLabel = onClickLabel,
         role = role,
     )
+
+@Composable
+fun Modifier.dropShadow(
+    shape: Shape,
+    color: Color = Color.Black.copy(0.25f),
+    blur: Dp = 4.dp,
+    offsetY: Dp = 4.dp,
+    offsetX: Dp = 0.dp,
+    spread: Dp = 0.dp
+) = this.drawBehind {
+    val shadowSize = Size(size.width + spread.toPx(), size.height + spread.toPx())
+    val shadowOutline = shape.createOutline(shadowSize, layoutDirection, this)
+
+    val paint = Paint().apply {
+        this.color = color
+    }
+
+    if (blur.toPx() > 0) {
+        paint.asFrameworkPaint().apply {
+            maskFilter = BlurMaskFilter(blur.toPx(), BlurMaskFilter.Blur.NORMAL)
+        }
+    }
+
+    drawIntoCanvas { canvas ->
+        canvas.save()
+        canvas.translate(offsetX.toPx(), offsetY.toPx())
+        canvas.drawOutline(shadowOutline, paint)
+        canvas.restore()
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,4 +1,9 @@
 <resources>
     <string name="app_name">BBANGZIP</string>
-    <string name="dummy">이거</string>
+
+    <!--bottomNavigation-->
+    <string name="bottomNavigation_first_tab_title">과목 관리</string>
+    <string name="bottomNavigation_second_tab_title">오늘 할 일</string>
+    <string name="bottomNavigation_third_tab_title">친구들</string>
+    <string name="bottomNavigation_fourth_tab_title">마이페이지</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2,8 +2,8 @@
     <string name="app_name">BBANGZIP</string>
 
     <!--bottomNavigation-->
-    <string name="bottomNavigation_first_tab_title">과목 관리</string>
-    <string name="bottomNavigation_second_tab_title">오늘 할 일</string>
-    <string name="bottomNavigation_third_tab_title">친구들</string>
-    <string name="bottomNavigation_fourth_tab_title">마이페이지</string>
+    <string name="bottomNavigation_subject_tab_title">과목 관리</string>
+    <string name="bottomNavigation_todo_tab_title">오늘 할 일</string>
+    <string name="bottomNavigation_friend_tab_title">친구들</string>
+    <string name="bottomNavigation_my_tab_title">마이페이지</string>
 </resources>


### PR DESCRIPTION
## Related issue 🛠
- closed #4 
- closed #11 

## Work Description ✏️
- bottom navigation 둥글게
- 그림자 주기
- 바텀네비게이션 깜빡임 현상 수정

## Screenshot 📸

|수정전|수정후|
|---|---|
|<video src="https://github.com/user-attachments/assets/5c7a9929-da07-4da1-8d64-48e5a45ae777">|<video src="https://github.com/user-attachments/assets/41cbba02-eb4f-40ec-8c6a-12575c9c754c">|

## To Reviewers 📢
1. 보기에 그림자가 좀 진한것 같지 않나요?
2. 오른쪽으로 클릭 할 때 깜빡이는 현상이 확실하게 보이네요. fix issue파서 한번 고쳐보겠습니다

## 수정사항
1. #11 이슈를 함께 수정하였습니다.
트러블 슈팅에 지레짐작해 이유를 적어놨는데 보시면 좋을 듯 하고 AnimatedVisibility의 기본값 중 shrinkOut 애니메이션과 충돌이 나 버그가 발생하였습니다.